### PR TITLE
README: add note about incompatiblity with @storybook/addon-backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npm i --save-dev @react-theming/storybook-addon
 
 ![example](https://raw.githubusercontent.com/react-theming/storybook-addon/master/docs/theme-panel.png)
 
+NB: This addon is **not** compatible with the [@storybook/addon-backgrounds](https://storybook.js.org/addons/@storybook/addon-backgrounds/). (Bundled with `@storybook/addon-essentials`)
+
 ## Features :dizzy:
 
 - Universal - can be used with any styling library


### PR DESCRIPTION
Ref: https://github.com/react-theming/storybook-addon/issues/21#issuecomment-869599720

Unless I've missed something? The comments seems reasonable and I did try a couple of things without success.