### PR TITLE
set @usulpro/react-json-view version to use ^2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,5 +123,8 @@
   "storybook": {
     "displayName": "React Theming"
   },
+  "resolutions": {
+    "@usulpro/react-json-view": "^2.0.1"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
By setting this version in the `resolutions` it is forcing any dependencies to use this particular version.

Resolves #32 