### PR TITLE
docs: update to align with Emotion v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Below the use cases for most popular styling libraries:
 ```js
 // .storybook/preview.js
 
-import { ThemeProvider } from 'emotion-theming';
+import { ThemeProvider } from '@emotion/react';
 import { addDecorator } from '@storybook/react';
 import { withThemes } from '@react-theming/storybook-addon';
 


### PR DESCRIPTION
In version 11 of Emotion there were a few changes made to the project structure;
> emotion-theming → moved into @emotion/react

Reference: 
https://emotion.sh/docs/emotion-11#package-renaming